### PR TITLE
Use util.inspect instead of JSON.stringify

### DIFF
--- a/lib/declarative-test.js
+++ b/lib/declarative-test.js
@@ -1,9 +1,17 @@
 'use strict';
 
+const util = require('util');
 const common = require('metarhia-common');
 
 const Test = require('./test');
 const { instance: runnerInstance } = require('./runner');
+
+const inspect = value => util.inspect(value, {
+  showHidden: true,
+  depth: null,
+  maxArrayLength: null,
+  breakLength: Infinity,
+});
 
 const defaultOptions = {
   run: true,
@@ -49,13 +57,13 @@ class DeclarativeTest extends Test {
 
         let sExpected;
         if (expectedType === 'function') sExpected = 'function';
-        else if (expectedType === 'string') sExpected = '"' + expected + '"';
-        else sExpected = JSON.stringify(expected);
+        else if (expectedType === 'string') sExpected = `'${expected}'`;
+        else sExpected = inspect(expected);
 
         if (targetType === 'method') target = definition.shift();
 
         const parameters = definition;
-        const sParameters = JSON.stringify(parameters);
+        const sParameters = inspect(parameters);
 
         let result;
         if (targetType === 'function') {
@@ -70,16 +78,16 @@ class DeclarativeTest extends Test {
         let sResult;
         if (result instanceof RegExp) {
           sResult = result.toString();
-          sResult = `"${sResult.substring(1, sResult.length - 1)}"`;
+          sResult = `'${sResult.substring(1, sResult.length - 1)}'`;
         } else if (result instanceof Buffer) {
           sResult = result.toString();
         } else {
-          sResult = JSON.stringify(result);
+          sResult = inspect(result);
         }
 
         let msg;
         if (targetType === 'method') {
-          const targetValue = target === null ? '' : JSON.stringify(target);
+          const targetValue = target === null ? '' : inspect(target);
           msg = `${targetType} of ${className}: ${targetValue}.${methodName}`;
         } else {
           msg = `${targetType} ${functionName}`;

--- a/lib/report.js
+++ b/lib/report.js
@@ -14,12 +14,16 @@ const LINE_LENGTH = 12;
 
 const lpad = (s, count, char = ' ') => (char.repeat(count - s.length) + s);
 
-const line = (title, s) => `\n${lpad(title, LINE_LENGTH)}: ${inspect(s)}`;
+const lineInspect =
+  (title, s) => `\n${lpad(title, LINE_LENGTH)}: ${inspect(s)}`;
+const line = (title, s) => `\n${lpad(title, LINE_LENGTH)}: ${s}`;
 
-const list = (lines, s = '', exclude = []) => {
+const list = (lines, s = '', inspect = [], exclude = []) => {
   for (const key in lines) {
     if (!exclude.includes(key)) {
-      s += line(capitalize(key), lines[key]);
+      s += inspect.includes(key) ?
+        lineInspect(capitalize(key), lines[key]) :
+        line(capitalize(key), lines[key]);
     }
   }
   return s;
@@ -117,7 +121,7 @@ class ConciseReporter extends Reporter {
   listFailure(test, res, message) {
     if (res.stack) res.stack = renderStack(res.stack);
     this.printAssertErrorSeparator();
-    console.log(list(res, message, ['success']) + '\n');
+    console.log(list(res, message, ['actual', 'expected'], ['success']) + '\n');
   }
 
   record(test) {

--- a/lib/report.js
+++ b/lib/report.js
@@ -1,15 +1,20 @@
 'use strict';
 
+const util = require('util');
 const { capitalize } = require('metarhia-common');
+
+const inspect = value => util.inspect(value, {
+  showHidden: true,
+  depth: null,
+  maxArrayLength: null,
+  breakLength: Infinity,
+});
 
 const LINE_LENGTH = 12;
 
 const lpad = (s, count, char = ' ') => (char.repeat(count - s.length) + s);
 
-const line = (title, s) => {
-  if (typeof s === 'object') s = JSON.stringify(s);
-  return `\n${lpad(title, LINE_LENGTH)}: ${s}`;
-};
+const line = (title, s) => `\n${lpad(title, LINE_LENGTH)}: ${inspect(s)}`;
 
 const list = (lines, s = '', exclude = []) => {
   for (const key in lines) {

--- a/test/declarative.js
+++ b/test/declarative.js
@@ -4,8 +4,9 @@ const metatests = require('..');
 
 const f1 = x => x * 2;
 const f2 = x => x + 3;
+const f3 = x => +x;
 
-const namespace = { submodule: { f1, f2 } };
+const namespace = { submodule: { f1, f2, f3 } };
 
 metatests.case('Declarative example', namespace, {
   'submodule.f1': [
@@ -17,5 +18,9 @@ metatests.case('Declarative example', namespace, {
     [1, 4],
     [2, 5],
     [3, 6],
-  ]
+  ],
+  'submodule.f3': [
+    [1, 1],
+    ['abc', Number.NaN],
+  ],
 });


### PR DESCRIPTION
This will fix https://github.com/metarhia/metatests/issues/63.
Also in the current 'declarative' checker, you can do 
`const f = x => x`
 and
`[Number.NaN, null]`
it will not fail.
This PR fixes that. Though I wanted to add a negative declarative test case but couldn't finds a way to do it, is it possible?

I ran `common` tests and found a [bug](https://github.com/metarhia/common/pull/166). Also tried `globalstorage` tests but it just hang indefinitely on mongo provider tests, do I need anything special (besides mongodb) to run them?