### PR TITLE
Improve assert failure reporting

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -6,19 +6,7 @@ const LINE_LENGTH = 12;
 
 const lpad = (s, count, char = ' ') => (char.repeat(count - s.length) + s);
 
-const line = (title, s) => {
-  if (typeof s === 'object') s = JSON.stringify(s);
-  return `\n${lpad(title, LINE_LENGTH)}: ${s}`;
-};
-
-const list = (lines, s = '', exclude = []) => {
-  for (const key in lines) {
-    if (!exclude.includes(key)) {
-      s += line(capitalize(key), lines[key]);
-    }
-  }
-  return s;
-};
+const line = (title, s) => `\n${lpad(title, LINE_LENGTH)}: ${s}`;
 
 const renderStack = stack => {
   const path = process.cwd();
@@ -112,7 +100,20 @@ class ConciseReporter extends Reporter {
   listFailure(test, res, message) {
     if (res.stack) res.stack = renderStack(res.stack);
     this.printAssertErrorSeparator();
-    console.log(list(res, message, ['success']) + '\n');
+    let s = message;
+    ['type', 'message', 'expected', 'actual', 'stack'].forEach(key => {
+      let value = res[key];
+      if (key === 'message' && !value) return;
+      if (key === 'actual' || key === 'expected') {
+        let type = typeof value;
+        if (type === 'object' && value !== null && value.constructor) {
+          type = value.constructor.name;
+        }
+        value = `${JSON.stringify(value)} is ${type}`;
+      }
+      s += line(capitalize(key), value);
+    });
+    console.log(`${s}\n`);
   }
 
   record(test) {


### PR DESCRIPTION
Parts of https://github.com/metarhia/metatests/pull/64 I wanted to have even without `util.inspect`.

This case:
```js
metatests.testSync('', (test) => test.strictSame('1', 1));
```
Was reported as:
```
 Test failed:

        Type: strictSame
       Stack: Error
            ImperativeTest.strictSame (/lib/imperative-test.js:194:10)
            ImperativeTest.metatests.testSync [as func] (/test/imperative.js:182:39)
            ImperativeTest.runNow (/lib/imperative-test.js:357:25)
            process.nextTick (/lib/imperative-test.js:346:12)
    Expected: 1
      Actual: 1
     Message: undefined
```

Now it is:
```
 Test failed:

        Type: strictSame
     Message: undefined
    Expected: 1 || number
      Actual: "1" || string
       Stack: Error
            ImperativeTest.strictSame (/lib/imperative-test.js:194:10)
            ImperativeTest.metatests.testSync [as func] (/test/imperative.js:183:39)
            ImperativeTest.runNow (/lib/imperative-test.js:357:25)
            process.nextTick (/lib/imperative-test.js:346:12)
```