### PR TITLE
Move failure exit from reporter -> runner

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -130,7 +130,6 @@ class ConciseReporter extends Reporter {
       'Asserts:        ' +
       `[+${this.successfulAsserts} | -${this.failedAsserts}]`
     );
-    if (this.failed > 0) process.exit(1);
   }
 
   printTestSeparator() {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -9,8 +9,10 @@ class Runner extends EventEmitter {
     super();
     this.options = Object.assign({ runTodo: false }, options);
     this.reporter = new ConciseReporter();
+    this.hasFailures = false;
     this.testsCount = 0;
     this._testDoneCallback = (test) => {
+      if (!test.success) this.hasFailures = true;
       this.reporter.record(test);
       if (--this.testsCount === 0) {
         process.nextTick(() => {
@@ -39,7 +41,9 @@ class Runner extends EventEmitter {
     // tests have finished (including test 'error' event).
     // Now we can have more events after this 'finish' event due to limitations
     // of imperative/declarative test implementaion (no proper test boxing).
-    this.emit('finish');
+    if (!this.emit('finish', this.hasFailures)) {
+      if (this.hasFailures) process.exit(1);
+    }
   }
 }
 


### PR DESCRIPTION
In case of failures there was a leftover 'process.exit(1)' in a reporter
implementation that shouldn't be there. With this it is now moved to
Runner which will exit if at least 1 test has failed *and* there is no
one listening on 'finish' event (the one who is listening is responsible
for exiting then).
'finish' event now contains hasFailures (boolean) argument.