### PR TITLE
Remove unnecessary exit-code test

### DIFF
--- a/test/assets.js
+++ b/test/assets.js
@@ -1,14 +1,7 @@
 'use strict';
 
 const { ImperativeTest } = require('..');
+
 const test = new ImperativeTest('Slave test');
-
-const fail = process.argv[2] === 'f';
-
-if (fail) {
-  test.fail('Failing test');
-} else {
-  test.pass('Passing test');
-}
-
+test.pass('Passing test');
 test.end();

--- a/test/exit-code.js
+++ b/test/exit-code.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const cp = require('child_process');
-
 const path = require('path');
 
 const metatests = require('..');
@@ -13,21 +12,6 @@ metatests.test('exit code of a passing test must be 0', test => {
 
   subtest.on('exit', code => {
     test.equal(code, 0);
-    test.end();
-  });
-
-  subtest.on('error', error => {
-    test.fail(error);
-  });
-});
-
-metatests.test('exit code of a failing test must not be 0', test => {
-  const subtest = cp.fork(path.join(__dirname, 'assets'), ['f'], {
-    stdio: 'ignore',
-  });
-
-  subtest.on('exit', code => {
-    test.notEqual(code, 0);
     test.end();
   });
 


### PR DESCRIPTION
This test in case of failure would still return 'success'
because if metatests has failed it would exit with code -1, not
necessary because the test we want has failed.