### PR TITLE
Don't mark finished tests as failures in Runner

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -26,13 +26,10 @@ class Runner extends EventEmitter {
   }
 
   addTest(test) {
+    this.testsCount++;
     test.on('error', this._testErrorCallback);
-    if (test.done) {
-      this.reporter.error(test, new Error('Added finished test'));
-    } else {
-      this.testsCount++;
-      test.on('done', this._testDoneCallback);
-    }
+    if (test.done) this._testDoneCallback(test);
+    else test.on('done', this._testDoneCallback);
   }
 
   finish() {


### PR DESCRIPTION
This situation is first of all unlikely and furthermore it doesn't make
sense to mark it as an error, it's just another Test that needs to be
processed.