### PR TITLE
Remove node 9 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - 6
   - 8
-  - 9
   - 10
 script:
   - npm test


### PR DESCRIPTION
Node 9 was marked as end-of-life at 2018-06-30.