### PR TITLE
Fix error stack missing important information

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -11,10 +11,9 @@ const line = (title, s) => `\n${lpad(title, LINE_LENGTH)}: ${s}`;
 const renderStack = stack => {
   const path = process.cwd();
   const lines = stack.split('\n');
-  lines.splice(1, 1);
   const result = lines.map((line, i) =>
-    ' '.repeat(i ? 12 : 0) +
-    line.trim().replace(/at /g, '').replace(path, '')
+    ' '.repeat(i ? LINE_LENGTH : 0) +
+    line.replace(/at /g, '').replace(path, '')
   ).filter(line => !line.includes('(internal/'));
   return result.join('\n');
 };


### PR DESCRIPTION
Also, update indentation, so that subsequent stack lines are to the left
of the first line start in the output.