### PR TITLE
Improve reporter output

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -6,7 +6,7 @@ const LINE_LENGTH = 12;
 
 const lpad = (s, count, char = ' ') => char.repeat(count - s.length) + s;
 
-const line = (title, s) => `\n${lpad(title, LINE_LENGTH)}: ${s}`;
+const line = (title, s) => '\n' + lpad(`${title}: `, LINE_LENGTH) + s;
 
 const renderStack = stack => {
   const path = process.cwd();
@@ -114,7 +114,7 @@ class ConciseReporter extends Reporter {
             if (type === 'object' && value !== null && value.constructor) {
               type = value.constructor.name;
             }
-            value = JSON.stringify(value);
+            value = JSON.stringify(value, null, 2);
           }
           if (value !== 'undefined' &&
               value !== 'null' &&


### PR DESCRIPTION
* Call `lpad()` with line title with ': ' included, thus reducing line
length.
* Add space padding to `JSON.stringify()`.