### PR TITLE
Implement dependent subtests

### DIFF
--- a/lib/imperative-test.js
+++ b/lib/imperative-test.js
@@ -12,6 +12,7 @@ const defaultTestOptions = {
   timeout: 30000,
   context: {},
   parallelSubtests: false,
+  dependentSubtests: false,
 };
 
 class ImperativeTest extends Test {
@@ -27,6 +28,12 @@ class ImperativeTest extends Test {
       .forEach(k => {
         this.options[k] = defaultTestOptions[k];
       });
+
+    if (this.options.parallelSubtests && this.options.dependentSubtests) {
+      throw new Error(
+        'parallelSubtests and dependentSubtests are contradictory'
+      );
+    }
 
     this.subtestId = 0;
     this.subtests = new Map();
@@ -46,11 +53,16 @@ class ImperativeTest extends Test {
   }
 
   _setupSubtestCallbacks() {
+    const { dependentSubtests } = this.options;
     const subtestCallbackEnd = test => {
       if (this.subtestQueue.length > 0 && test.id === this.subtestQueue[0].id) {
         this.subtestQueue.shift();
         if (this.subtestQueue.length > 0) {
-          this._runSubtest(this.subtestQueue[0]);
+          if (dependentSubtests && !test.success) {
+            this.fail(`Dependent subtest failure: ${test.id}/${test.title}`);
+          } else {
+            this._runSubtest(this.subtestQueue[0]);
+          }
           return;
         }
       }

--- a/test/imperative.js
+++ b/test/imperative.js
@@ -441,3 +441,26 @@ metatests.test('failed todo subtest must not fail parent', test => {
     test.end();
   });
 });
+
+metatests.test('dependentSubtests and parallelSubtests are exclusive', test => {
+  test.throws(() => {
+    new metatests.ImperativeTest(
+      'throwing',
+      () => {},
+      { parallelSubtests: true, dependentSubtests: true }
+    );
+  }, new Error('parallelSubtests and dependentSubtests are contradictory'));
+  test.end();
+});
+
+metatests.test('must support dependentSubtests', test => {
+  const t = new metatests.ImperativeTest('mustNotCall test', t => {
+    t.testSync('successful subtest', test.mustCall(t => t.pass()));
+    t.testSync('failing subtest', test.mustCall(t => t.fail()));
+    t.testSync('successful subtest', test.mustNotCall(t => t.pass()));
+  }, { async: false, dependentSubtests: true });
+  t.on('done', () => {
+    test.strictSame(t.success, false);
+    test.end();
+  });
+});


### PR DESCRIPTION
Adds options dependentSubtests that if specified will make parent test
'test.fail' if it subtest fails.