### PR TITLE
Implement test.bailout that will cease execution

### DIFF
--- a/lib/imperative-test.js
+++ b/lib/imperative-test.js
@@ -15,6 +15,8 @@ const defaultTestOptions = {
   dependentSubtests: false,
 };
 
+class BailoutError extends Error {}
+
 class ImperativeTest extends Test {
 
   // TODO(lundibundi): Current implementaion will not fail if
@@ -322,6 +324,16 @@ class ImperativeTest extends Test {
     };
   }
 
+  bailout(message) {
+    this.results.push({
+      type: 'bailout',
+      success: false,
+      message,
+      stack: new Error().stack,
+    });
+    throw new BailoutError();
+  }
+
   end() {
     if (this.subtests.size > 0 || this.subtestQueue.length > 0) {
       this.results.push({
@@ -414,7 +426,10 @@ class ImperativeTest extends Test {
   runNow() {
     if (!this.func) return;
     const funcDomain = domain.create();
-    funcDomain.on('error', e => this.erroer('unhandledExeption', e));
+    funcDomain.on('error', e => {
+      if (e instanceof BailoutError) this._end();
+      else this.erroer('unhandledExeption', e);
+    });
     funcDomain.run(() => this.func(this, this.context));
     this.on('done', () => funcDomain.exit());
   }

--- a/test/imperative.js
+++ b/test/imperative.js
@@ -497,3 +497,14 @@ metatests.test('must support dependentSubtests', test => {
     test.end();
   });
 });
+
+metatests.test('must support bailout', test => {
+  const t = new metatests.ImperativeTest('bailout test', t => {
+    t.bailout();
+    test.fail('must not be called');
+  });
+  t.on('done', () => {
+    test.strictSame(t.success, false);
+    test.end();
+  });
+});

--- a/test/imperative.js
+++ b/test/imperative.js
@@ -248,9 +248,13 @@ metatests.test('test.testAsync must be async', test => {
     'Sync test',
     undefined,
     { async: false });
-  t.testAsync('async test', () => setTimeout(() => t.end(), 10));
+  let endCalled = false;
+  t.testAsync('async test', () => setTimeout(() => {
+    t.end();
+    endCalled = true;
+  }, 10));
   process.nextTick(() => process.nextTick(() => process.nextTick(() => {
-    if (t.done) {
+    if (t.done && !endCalled) {
       test.fail('must not finish before t.end() call');
     }
   })));


### PR DESCRIPTION
Also, what do you think of making `test.error` to exit in case of error (`bailout`)?