### PR TITLE
Fix comparison in declarative tests

### DIFF
--- a/lib/declarative-test.js
+++ b/lib/declarative-test.js
@@ -3,6 +3,7 @@
 const domain = require('domain');
 const common = require('metarhia-common');
 
+const compare = require('./compare');
 const Test = require('./test');
 const { instance: runnerInstance } = require('./runner');
 
@@ -99,7 +100,7 @@ class DeclarativeTest extends Test {
 
         const success = expectedType === 'function' ?
           expected(result) :
-          sResult === sExpected;
+          compare.strictEqual(expected, result);
 
         this.results.push({
           success,

--- a/test/declarative.js
+++ b/test/declarative.js
@@ -4,8 +4,9 @@ const metatests = require('..');
 
 const f1 = x => x * 2;
 const f2 = x => x + 3;
+const f3 = x => x;
 
-const namespace = { submodule: { f1, f2 } };
+const namespace = { submodule: { f1, f2, f3 } };
 
 metatests.case('Declarative example', namespace, {
   'submodule.f1': [
@@ -17,5 +18,8 @@ metatests.case('Declarative example', namespace, {
     [1, 4],
     [2, 5],
     [3, 6],
+  ],
+  'submodule.f3': [
+    ['\\', '\\'],
   ],
 });


### PR DESCRIPTION
Declarative tests compared actual and expected values by serializing
them in different formats before comparison.

Closes: https://github.com/metarhia/metatests/issues/123