### PR TITLE
Fix crash on unhandledException in dependentSubtests

### DIFF
--- a/lib/imperative-test.js
+++ b/lib/imperative-test.js
@@ -61,7 +61,10 @@ class ImperativeTest extends Test {
         this.subtestQueue.shift();
         if (this.subtestQueue.length > 0) {
           if (dependentSubtests && !test.success) {
-            this.bailout(`Dependent subtest failure: ${test.id}/${test.title}`);
+            process.nextTick(() => {
+              const msg = `Dependent subtest failure: ${test.id}/${test.title}`;
+              this.bailout(msg);
+            });
           } else {
             this._runSubtest(this.subtestQueue[0]);
           }

--- a/test/imperative.js
+++ b/test/imperative.js
@@ -512,3 +512,19 @@ metatests.test('must support bailout', test => {
     test.end();
   });
 });
+
+metatests.test('must not crash on exception in dependentSubtests', test => {
+  const t = new metatests.ImperativeTest('parent test', t => {
+    t.endAfterSubtests();
+    t.test('throwing subtest', test.mustCall(() => {
+      setImmediate(() => {
+        throw new Error();
+      });
+    }));
+    t.testSync('successful subtest', test.mustNotCall());
+  }, { dependentSubtests: true });
+  t.on('done', () => {
+    test.strictSame(t.success, false);
+    test.end();
+  });
+});


### PR DESCRIPTION
Alternative to https://github.com/metarhia/metatests/pull/128.