### PR TITLE
Properly check Error instance in test.error()

### DIFF
--- a/lib/imperative-test.js
+++ b/lib/imperative-test.js
@@ -247,7 +247,7 @@ class ImperativeTest extends Test {
   error(err, message) {
     this._check(
       'error',
-      err => !(err instanceof Error),
+      err => Object.prototype.toString.call(err) !== '[object Error]',
       err,
       null,
       message

--- a/test/imperative.js
+++ b/test/imperative.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const metatests = require('..');
+const vm = require('vm');
 
 metatests.testSync('strictSame', test => {
   test.strictSame(1, 1);
@@ -523,6 +524,23 @@ metatests.test('must not crash on exception in dependentSubtests', test => {
     }));
     t.testSync('successful subtest', test.mustNotCall());
   }, { dependentSubtests: true });
+  t.on('done', () => {
+    test.strictSame(t.success, false);
+    test.end();
+  });
+});
+
+metatests.test('must support Error from another context', test => {
+  const t = new metatests.ImperativeTest('mustNotCall test', t => {
+    let err = null;
+    try {
+      vm.runInNewContext('throw new Error()');
+    } catch (e) {
+      err = e;
+    }
+    t.error(err);
+    t.end();
+  });
   t.on('done', () => {
     test.strictSame(t.success, false);
     test.end();


### PR DESCRIPTION
Previously it wouldn't catch errors created in another context.

Co-authored-by: Mykola Bilochub <nbelochub@gmail.com>