### PR TITLE
Allow to pass Error to test.bailout

### DIFF
--- a/lib/imperative-test.js
+++ b/lib/imperative-test.js
@@ -324,12 +324,21 @@ class ImperativeTest extends Test {
     };
   }
 
-  bailout(message) {
+  bailout(err, message) {
+    if (typeof err === 'string') {
+      message = err;
+      err = null;
+    }
+    if (err) {
+      if (message) message += '\n';
+      else message = '';
+      message += err.toString();
+    }
     this.results.push({
       type: 'bailout',
       success: false,
       message,
-      stack: new Error().stack,
+      stack: err ? err.stack : new Error().stack,
     });
     throw new BailoutError();
   }

--- a/test/imperative.js
+++ b/test/imperative.js
@@ -546,3 +546,46 @@ metatests.test('must support Error from another context', test => {
     test.end();
   });
 });
+
+metatests.test('must support bailout message', test => {
+  const message = 'message';
+  const t = new metatests.ImperativeTest('bailout test', t => {
+    t.bailout(message);
+  });
+  t.on('done', () => {
+    test.strictSame(t.success, false);
+    test.strictSame(t.results[0].type, 'bailout');
+    test.strictSame(t.results[0].message, 'message');
+    test.end();
+  });
+});
+
+metatests.test('must support bailout error', test => {
+  const error = new Error('err');
+  const t = new metatests.ImperativeTest('bailout test', t => {
+    t.bailout(error);
+  });
+  t.on('done', () => {
+    test.strictSame(t.success, false);
+    test.strictSame(t.results[0].type, 'bailout');
+    test.strictSame(t.results[0].message, error.toString());
+    test.strictSame(t.results[0].stack, error.stack);
+    test.end();
+  });
+});
+
+metatests.test('must support bailout message and error', test => {
+  const message = 'message';
+  const error = new Error('err');
+  const t = new metatests.ImperativeTest('bailout test', t => {
+    t.bailout(error, message);
+  });
+  t.on('done', () => {
+    const expectedMessage = `${message}\n${error.toString()}`;
+    test.strictSame(t.success, false);
+    test.strictSame(t.results[0].type, 'bailout');
+    test.strictSame(t.results[0].message, expectedMessage);
+    test.strictSame(t.results[0].stack, error.stack);
+    test.end();
+  });
+});


### PR DESCRIPTION
This will lead to a following behavior:
* if only message is passed then it will be recorded as is
* if err is passed message will be err.toString() and stack - err.stack
* if message and err is passed then message will be
  `message\nerr.toString()` and stack - err.stack