### PR TITLE
Fix filename resolution for renamed package directory

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -1,9 +1,15 @@
 'use strict';
 
 const { EventEmitter } = require('events');
+const path = require('path');
 const { callerFilepath } = require('@metarhia/common');
 
 let nextTestId = 0;
+
+const packageDir = path.basename(path.join(__dirname, '..'));
+const packageRegex = new RegExp(
+  `${path.sep}${packageDir}${path.sep}lib${path.sep}.*test\\.js`
+);
 
 module.exports = class Test extends EventEmitter {
   constructor(caption, options) {
@@ -20,7 +26,7 @@ module.exports = class Test extends EventEmitter {
     let depth = 1;
     do {
       filepath = callerFilepath(depth++);
-    } while (filepath && filepath.match(/\/metatests\/lib\/.*test\.js/));
+    } while (filepath && filepath.match(packageRegex));
     this.metadata = { filepath };
   }
 


### PR DESCRIPTION
Previously name resolution would fail if the folder with 'metatests'
was called something different than 'metatests' due to the name being
hardcoded. This commit makes so that the name is resolved during first
require of the file.