### PR TITLE
Implement test.cb/cbFail to avoid error handling boilerplate code

### DIFF
--- a/lib/imperative-test.js
+++ b/lib/imperative-test.js
@@ -377,6 +377,33 @@ class ImperativeTest extends Test {
     throw new BailoutError();
   }
 
+  cb(msg, cb) {
+    if (typeof msg === 'function') {
+      cb = msg;
+      msg = undefined;
+    }
+    return this.mustCall((err, ...res) => {
+      this.error(err, msg);
+      if (cb) cb(err, ...res);
+    });
+  }
+
+  cbFail(fail, cb) {
+    if (typeof fail === 'function') {
+      cb = fail;
+      fail = undefined;
+    }
+    return this.mustCall((err, ...res) => {
+      this.error(err);
+      if (err) {
+        this.fail(fail);
+        this.end();
+      } else if (cb) {
+        cb(err, ...res);
+      }
+    });
+  }
+
   end() {
     if (this.subtests.size > 0 || this.subtestQueue.length > 0) {
       this.results.push({

--- a/test/test-cb.js
+++ b/test/test-cb.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const { test, ImperativeTest } = require('..');
+
+test('test.cb with message', test => {
+  const message = 'hello';
+  const t = new ImperativeTest('cb test', t => {
+    const cb = t.cb(message);
+    cb(null);
+    t.end();
+  });
+  t.on('done', () => {
+    test.assert(t.success);
+    test.end();
+  });
+});
+
+test('test.cb with message and callback', test => {
+  const message = 'hello';
+  const t = new ImperativeTest('cb test', t => {
+    const cb = t.cb(message, test.mustCall());
+    cb(null);
+    t.end();
+  });
+  t.on('done', () => {
+    test.assert(t.success);
+    test.end();
+  });
+});
+
+test('test.cb must assert mustCall', test => {
+  const t = new ImperativeTest('cb test', t => {
+    t.cb();
+    t.end();
+  });
+  t.on('done', () => {
+    const res = t.results[0];
+    test.assertNot(t.success);
+    test.strictSame(res.type, 'mustCall');
+    test.strictSame(res.expected, 1);
+    test.strictSame(res.actual, 0);
+    test.end();
+  });
+});
+
+test('test.cb must forward error', test => {
+  const message = 'hello';
+  const t = new ImperativeTest('cb test', t => {
+    const error = new Error('err');
+    const cb = t.cb(
+      message,
+      test.mustCall(err => {
+        test.isError(err, error);
+        t.end();
+      })
+    );
+    cb(error);
+  });
+  t.on('done', () => {
+    test.assertNot(t.success);
+    test.end();
+  });
+});
+
+test('test.cb must forward results', test => {
+  const t = new ImperativeTest('cb test', t => {
+    const data = [1, 2, 3];
+    const cb = t.cb(
+      test.mustCall((err, ...res) => {
+        test.error(err);
+        test.strictSame(res, data);
+        t.end();
+      })
+    );
+    cb(null, ...data);
+  });
+  t.on('done', () => {
+    test.assert(t.success);
+    test.end();
+  });
+});
+
+test('test.cbFail must support message', test => {
+  const fail = 'hello';
+  const t = new ImperativeTest('cbFail test', t => {
+    const cb = t.cbFail(fail, test.mustNotCall());
+    cb(new Error());
+  });
+  t.on('done', () => {
+    test.assertNot(t.success);
+    test.strictSame(t.results[0].type, 'error');
+    test.strictSame(t.results[1].type, 'fail');
+    test.strictSame(t.results[1].message, fail);
+    test.end();
+  });
+});
+
+test('test.cbFail must assert mustCall', test => {
+  const t = new ImperativeTest('cbFail test', t => {
+    t.cbFail();
+    t.end();
+  });
+  t.on('done', () => {
+    const res = t.results[0];
+    test.assertNot(t.success);
+    test.strictSame(res.type, 'mustCall');
+    test.strictSame(res.expected, 1);
+    test.strictSame(res.actual, 0);
+    test.end();
+  });
+});
+
+test('test.cbFail must forward results', test => {
+  const data = [1, 2, 3];
+  const t = new ImperativeTest('cbFail test', t => {
+    const cb = t.cbFail(
+      test.mustCall((err, ...res) => {
+        test.error(err);
+        test.strictSame(res, data);
+        t.end();
+      })
+    );
+    cb(null, ...data);
+  });
+  t.on('done', () => {
+    test.assert(t.success);
+    test.end();
+  });
+});


### PR DESCRIPTION
With this, it is now possible to replace usual callback boilerplate code with

```js
fs.writeFile('file.txt', data, test.cb());
```
```js
fs.readFile('file.txt', test.cb((err, data) => {
  // test.error(err) was already called
});
```

Or avoiding callback call in case of error with
```js
fs.readFile('file.txt', test.cb({ fail: 'Cannot read file' }, (err, data) => {
  // err is null or undefined here
});
```

Also, I consider splitting current implementation of `test.cb` in 2 functions `test.cb` that will only execute `test.error` and `test.cbFail` that will behave as current `test.cb({ fail: 'message' }, cb)`. WDYT?

/cc @belochub @nechaido @SemenchenkoVitaliy 