### PR TITLE
Remove 'err' argument from cbFail callback

### DIFF
--- a/lib/imperative-test.js
+++ b/lib/imperative-test.js
@@ -399,7 +399,7 @@ class ImperativeTest extends Test {
         this.fail(fail);
         this.end();
       } else if (cb) {
-        cb(err, ...res);
+        cb(...res);
       }
     });
   }

--- a/test/test-cb.js
+++ b/test/test-cb.js
@@ -114,8 +114,7 @@ test('test.cbFail must forward results', test => {
   const data = [1, 2, 3];
   const t = new ImperativeTest('cbFail test', t => {
     const cb = t.cbFail(
-      test.mustCall((err, ...res) => {
-        test.error(err);
+      test.mustCall((...res) => {
         test.strictSame(res, data);
         t.end();
       })


### PR DESCRIPTION
Closes: https://github.com/metarhia/metatests/issues/149