### PR TITLE
Allow to pass afterAll callback to cbFail

### DIFF
--- a/lib/imperative-test.js
+++ b/lib/imperative-test.js
@@ -388,8 +388,9 @@ class ImperativeTest extends Test {
     });
   }
 
-  cbFail(fail, cb) {
+  cbFail(fail, cb, afterAllCb) {
     if (typeof fail === 'function') {
+      afterAllCb = cb;
       cb = fail;
       fail = undefined;
     }
@@ -401,6 +402,7 @@ class ImperativeTest extends Test {
       } else if (cb) {
         cb(err, ...res);
       }
+      if (afterAllCb) afterAllCb(err);
     });
   }
 

--- a/test/test-cb.js
+++ b/test/test-cb.js
@@ -127,3 +127,33 @@ test('test.cbFail must forward results', test => {
     test.end();
   });
 });
+
+test('test.cbFail must call afterAllCb on success', test => {
+  const t = new ImperativeTest('cbFail test', t => {
+    const cb = t.cbFail(test.mustCall(), err => {
+      test.error(err);
+      t.end();
+    });
+    cb(null);
+  });
+  t.on('done', () => {
+    test.assert(t.success);
+    test.end();
+  });
+});
+
+test('test.cbFail must call afterAllCb on error', test => {
+  const error = new Error('hello');
+  new ImperativeTest('cbFail test', t => {
+    const cb = t.cbFail(
+      test.mustNotCall(),
+      test.mustCall(err => {
+        test.strictSame(err, error);
+        test.assert(t.done);
+        test.assertNot(t.success);
+        test.end();
+      })
+    );
+    cb(error);
+  });
+});


### PR DESCRIPTION
This will allow to also use this function when additional callback needs
to be called. (e.g. from test.beforeEach or test.afterEach).

e.g.
```js
test('test', test => {
  test.beforeEach((t, cb) => {
    metasync.sequential([
      (ctx, cb) => method1('a', t.cbFail(data => ctx.a = data, cb)),
      (ctx, cb) => method2('b', t.cbFail(data => ctx.b = data, cb)),
    ], cb);
  });

  test.beforeEach((t, cb) => {
    method('a', t.cbFail(data => console.log(data), () => cb()));
  });
});
```