### PR TITLE
Release version 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metatests",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metatests",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "author": "Timur Shemsedinov <timur.shemsedinov@gmail.com>",
   "description": "Simple to use test engine for Metarhia technology stack",
   "license": "MIT",


### PR DESCRIPTION
This includes:
* 'Remove 'err' argument from cbFail callback' - to fix the linter errors
  as the err is alway null in the callback. (BREAKING)
* 'Don't call subtest function if test ended in beforeEach' - avoids
  having 'test after end' and such errors when using `test.end()`
  in beforeEach.
* 'Allow to pass afterAll callback to cbFail' - adds 3rd optional
  parameter to the `cbFail` to be called after the main callback
  was handled. Error will be forwarded in this callback if it present.