### PR TITLE
Align ImperativeTest constructor with the usage

### DIFF
--- a/lib/imperative-test.js
+++ b/lib/imperative-test.js
@@ -27,6 +27,14 @@ class ImperativeTest extends Test {
   // you have any tests past the 'plan' or after 'end' but it should
 
   constructor(caption, func, options) {
+    if (func !== null && typeof func === 'object') {
+      options = func;
+      func = undefined;
+    }
+    if (typeof caption === 'function') {
+      func = caption;
+      caption = undefined;
+    }
     super(caption, options);
 
     Object.keys(defaultTestOptions)

--- a/test/imperative.js
+++ b/test/imperative.js
@@ -163,18 +163,19 @@ metatests.testSync('beforeEach parameters', test => {
 });
 
 metatests.test('afterEach', test => {
-  test.plan(3);
+  test.endAfterSubtests();
+
   let i = 0;
   test.afterEach((t, callback) => {
-    test.pass('must call afterEach');
+    test.strictSame(i, 13);
     i = 42;
     callback();
   });
-  const t = test.testSync(() => {
-    test.pass('must call test');
+  test.testSync(() => {
+    test.strictSame(i, 0);
     i = 13;
   });
-  t.on('done', () => test.strictSame(i, 42));
+  test.on('beforeDone', () => test.strictSame(i, 42));
 });
 
 metatests.testSync('test must fail if assertion failed', test => {


### PR DESCRIPTION
Currently code in tests uses test.testSync(() => {}) which was not
correctly handled in the constructor. This commit allows to pass
(func, undefined, options), (func, options) to the constructor.