### PR TITLE
Fix reporter console

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -60,7 +60,7 @@ class ConciseReporter extends Reporter {
     this.skipped = 0;
     this.successfulAsserts = 0;
     this.failedAsserts = 0;
-    this.console = new Console(this.options.stream);
+    this.console = Console ? new Console(this.options.stream) : console;
   }
 
   error(test, error) {
@@ -195,7 +195,7 @@ class TapReporter extends Reporter {
       ? // TODO: do .pipe(this.options.stream) as soon as TSR supports it
         new TSR(this.options.type)
       : this.options.stream;
-    this.console = new Console(writeStream);
+    this.console = Console ? new Console(writeStream) : console;
     this.successful = 0;
     this.failed = 0;
     this.skipped = 0;


### PR DESCRIPTION
If `console.Console` class is not available reporter will use `console` instead.

/cc @lundibundi @belochub @nechaido 