### PR TITLE
Fix worker require and default test output type

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -115,7 +115,7 @@ const getConfig = () => {
   config.files = exclude(config.files, config.exclude);
 
   config.logLevel = args.logLevel || config.logLevel || 'default';
-  config.reporter = args.reporter || config.reporter || 'default';
+  config.reporter = args.reporter || config.reporter || 'tap';
   config.runTodo = args.runTodo || config.runTodo;
   config.exitTimeout =
     args.exitTimeout || config.exitTimeout || DEFAULT_EXIT_TIMEOUT;
@@ -126,7 +126,10 @@ const runNode = (config, cb) => {
   if (config.logLevel === 'quiet') {
     runner.removeReporter();
   } else if (config.reporter.startsWith('tap')) {
-    const reporterType = config.reporter.split('-')[1];
+    let reporterType = config.reporter.split('-')[1];
+    if (!reporterType) {
+      reporterType = process.stdout.isTTY ? 'classic' : 'tap';
+    }
     runner.setReporter(
       new metatests.reporters.TapReporter({ type: reporterType })
     );

--- a/lib/report.js
+++ b/lib/report.js
@@ -201,11 +201,10 @@ const tapTestCaption = (id, test) => {
 class TapReporter extends Reporter {
   constructor(options) {
     super(options);
-    if (!this.options.type) {
-      this.options.type = this.options.stream.isTTY ? 'classic' : 'tap';
+    if (this.options.type && this.options.type !== 'tap') {
+      // TODO: do .pipe(this.options.stream) as soon as TSR supports it
+      this.options.stream = new TSR(this.options.type);
     }
-    // TODO: do .pipe(this.options.stream) as soon as TSR supports it
-    this.options.stream = new TSR(this.options.type);
     this.successful = 0;
     this.failed = 0;
     this.skipped = 0;

--- a/lib/report.js
+++ b/lib/report.js
@@ -1,9 +1,16 @@
 'use strict';
 
 const { iter, capitalize } = require('@metarhia/common');
-const TSR = require('tap-mocha-reporter');
 
 const { inspect, packageRegex } = require('./utils');
+
+let TSR = null;
+const lazyTSR = (...args) => {
+  if (!TSR) {
+    TSR = require('tap-mocha-reporter');
+  }
+  return new TSR(...args);
+};
 
 const LINE_LENGTH = 12;
 
@@ -201,9 +208,17 @@ const tapTestCaption = (id, test) => {
 class TapReporter extends Reporter {
   constructor(options) {
     super(options);
-    if (this.options.type && this.options.type !== 'tap') {
-      // TODO: do .pipe(this.options.stream) as soon as TSR supports it
-      this.options.stream = new TSR(this.options.type);
+    // TODO(lundibundi): fix (remove) this once TSR properly supports require from worker_threads
+    const { type } = this.options;
+    if (type && type !== 'tap') {
+      let stream = null;
+      Object.defineProperty(this.options, 'stream', {
+        get() {
+          // TODO: do .pipe(this.options.stream) as soon as TSR supports it
+          if (!stream) stream = lazyTSR(type);
+          return stream;
+        },
+      });
     }
     this.successful = 0;
     this.failed = 0;

--- a/test/test-worker-require.js
+++ b/test/test-worker-require.js
@@ -1,0 +1,18 @@
+'use strict';
+
+if (process.version.slice(1).split('.')[0] < 11) {
+  return;
+}
+
+const metatests = require('..');
+// eslint-disable-next-line import/no-unresolved
+const { Worker, isMainThread } = require('worker_threads');
+
+if (isMainThread) {
+  metatests.test('must not fail on require in worker_threads', test => {
+    const w = new Worker(__filename);
+    w.on('exit', () => {
+      test.end();
+    });
+  });
+}

--- a/test/test-worker-test.js
+++ b/test/test-worker-test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+if (process.version.slice(1).split('.')[0] < 11) {
+  return;
+}
+
+const metatests = require('..');
+// eslint-disable-next-line import/no-unresolved
+const { Worker, isMainThread } = require('worker_threads');
+
+if (isMainThread) {
+  metatests.test('must support tests in worker_threads', test => {
+    // stdout: true to avoid unnecessary output
+    const w = new Worker(__filename, { stdout: true });
+    w.on('exit', () => {
+      test.end();
+    });
+  });
+} else {
+  metatests.test('in worker test', test => {
+    test.strictSame(1, 1);
+    test.end();
+  });
+}


### PR DESCRIPTION
See commit messages.

Also, @SemenchenkoVitaliy could you check that this won't introduce any problems for `metatests-browser-runner`?