### PR TITLE
Add error to the test.fail signature

### DIFF
--- a/lib/imperative-test.js
+++ b/lib/imperative-test.js
@@ -283,11 +283,16 @@ class ImperativeTest extends Test {
     this._check('assertNot', value => !value, value, false, message);
   }
 
-  fail(message) {
+  fail(message, err) {
+    if (typeof message !== 'string') {
+      err = message;
+      message = undefined;
+    }
     this.results.push({
       type: 'fail',
       success: false,
       message,
+      actual: err,
       stack: new Error().stack,
     });
     this._passCheck();

--- a/test/imperative.js
+++ b/test/imperative.js
@@ -317,20 +317,6 @@ metatests.test('must support timeout', test => {
   });
 });
 
-metatests.test("'fail' result must not contain actual/expected", test => {
-  const t = new metatests.ImperativeTest('Failing test', t => {
-    t.fail('msg');
-    t.end();
-  });
-  t.on('done', () => {
-    test.strictSame(t.results[0].type, 'fail');
-    test.strictSame(t.results[0].message, 'msg');
-    test.assertNot(t.results[0].hasOwnProperty('actual'));
-    test.assertNot(t.results[0].hasOwnProperty('expected'));
-    test.end();
-  });
-});
-
 metatests.test("'pass' result must not contain actual/expected", test => {
   const t = new metatests.ImperativeTest('Pass test', t => {
     t.pass('msg');

--- a/test/test-imperative-fail.js
+++ b/test/test-imperative-fail.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const metatests = require('..');
+
+metatests.test('must support test.fail()', test => {
+  const t = new metatests.ImperativeTest('Failing test', t => {
+    t.fail('msg');
+    t.end();
+  });
+  t.on('done', () => {
+    test.strictSame(t.results[0].type, 'fail');
+    test.strictSame(t.results[0].message, 'msg');
+    test.strictSame(t.results[0].actual, undefined);
+    test.strictSame(t.results[0].expected, undefined);
+    test.end();
+  });
+});
+
+metatests.test('must support test.fail(msg, err)', test => {
+  const err = new Error('error');
+  const t = new metatests.ImperativeTest('Failing test', t => {
+    t.fail('msg', err);
+    t.end();
+  });
+  t.on('done', () => {
+    test.strictSame(t.results[0].type, 'fail');
+    test.strictSame(t.results[0].message, 'msg');
+    test.strictSame(t.results[0].actual, err);
+    test.strictSame(t.results[0].expected, undefined);
+    test.end();
+  });
+});
+
+metatests.test('must support test.fail(err)', test => {
+  const err = new Error('error');
+  const t = new metatests.ImperativeTest('Failing test', t => {
+    t.fail(err);
+    t.end();
+  });
+  t.on('done', () => {
+    test.strictSame(t.results[0].type, 'fail');
+    test.strictSame(t.results[0].actual, err);
+    test.strictSame(t.results[0].message, undefined);
+    test.strictSame(t.results[0].expected, undefined);
+    test.end();
+  });
+});


### PR DESCRIPTION
This will allow to pass Error to be recorded in 'actual' field of
the result to test.fail().