### PR TITLE
Fix incorrect assert in tests

### DIFF
--- a/test/unit/test._end-not-done-with-error.js
+++ b/test/unit/test._end-not-done-with-error.js
@@ -16,4 +16,3 @@ assert(onErrorCalled, 'onError must not be called');
 
 assert.strictEqual(test.done, true);
 assert.strictEqual(test.succeeded, false);
-assert.strictEqual();


### PR DESCRIPTION
This assertion is useless and leads to an error on Node.js 12+.