### PR TITLE
fix: remove !error tag from Tap stringify on Error instances

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -204,7 +204,15 @@ const tapTestCaption = (id, test) => {
   return msg;
 };
 
-const dump = val => '\n' + yaml.stringify(val);
+const dump = val => {
+  let res = yaml.stringify(val);
+  if (val instanceof Error) {
+    // remove !error tag to avoid info stripping by different tap reporters
+    // with this it will be displayed as an object
+    res = res.slice(res.indexOf('\n') + 1);
+  }
+  return '\n' + res;
+};
 
 class TapReporter extends Reporter {
   constructor(options) {


### PR DESCRIPTION
This will make it displayed as a simple object by different Tap
reporters and avoid stripping necessary info.

Closes: https://github.com/metarhia/metatests/issues/211