### PR TITLE
fix: properly compare ES6 Map and Set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Comparison of `Map` and `Set` objects.
+
 ## [0.7.2][] - 2020-07-27
 
 ### Added

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -164,7 +164,7 @@ const runNode = (config, cb) => {
     );
   }
   merge(config.files, config.nodeOnly).forEach(name => {
-    require(path.join(process.cwd(), name));
+    require(path.isAbsolute(name) ? name : path.join(process.cwd(), name));
   });
 };
 

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -1,5 +1,21 @@
 'use strict';
 
+const { iter } = require('@metarhia/common');
+
+const compareMaps = compare => (map1, map2) => {
+  if (map1.size !== map2.size) return false;
+  return iter(map1)
+    .zip(map2)
+    .every(([kv1, kv2]) => compare(kv1, kv2));
+};
+
+const compareSets = compare => (set1, set2) => {
+  if (set1.size !== set2.size) return false;
+  return iter(set1)
+    .zip(set2)
+    .every(([v1, v2]) => compare(v1, v2));
+};
+
 const equalArray = (arr1, arr2) => {
   const len1 = arr1.length;
   const len2 = arr2.length;
@@ -10,8 +26,16 @@ const equalArray = (arr1, arr2) => {
   return true;
 };
 
+const equalMap = compareMaps(equal);
+const equalSet = compareSets(equal);
+
 const equalObject = (obj1, obj2) => {
   if (obj1 === null || obj2 === null) return obj1 === obj2;
+  const obj1Name = obj1.constructor && obj1.constructor.name;
+  const obj2Name = obj2.constructor && obj2.constructor.name;
+  if (obj1Name !== obj2Name) return false;
+  if (obj1Name === 'Map') return equalMap(obj1, obj2);
+  if (obj1Name === 'Set') return equalSet(obj1, obj2);
   const keys1 = Object.keys(obj1);
   const keys2 = Object.keys(obj2);
   const len1 = keys1.length;
@@ -60,8 +84,16 @@ const strictEqualArray = (arr1, arr2) => {
   return true;
 };
 
+const strictEqualMap = compareMaps(strictEqual);
+const strictEqualSet = compareSets(strictEqual);
+
 const strictEqualObject = (obj1, obj2) => {
   if (obj1 === null || obj2 === null) return obj1 === obj2;
+  const obj1Name = obj1.constructor && obj1.constructor.name;
+  const obj2Name = obj2.constructor && obj2.constructor.name;
+  if (obj1Name !== obj2Name) return false;
+  if (obj1Name === 'Map') return strictEqualMap(obj1, obj2);
+  if (obj1Name === 'Set') return strictEqualSet(obj1, obj2);
   const keys1 = Object.keys(obj1);
   const keys2 = Object.keys(obj2);
   const len1 = keys1.length;

--- a/test/imperative.js
+++ b/test/imperative.js
@@ -580,3 +580,48 @@ if (__filename) {
     t.end();
   });
 }
+
+metatests.testSync('must support simple Map comparison', test => {
+  test.strictEqual(
+    new Map([
+      [1, 'a'],
+      [2, 'b'],
+    ]),
+    new Map([
+      [1, 'a'],
+      [2, 'b'],
+    ])
+  );
+});
+
+metatests.test('must support simple Map comparison failure', test => {
+  const t = new metatests.ImperativeTest('mustCall test', t => {
+    t.strictEqual(
+      new Map([[1, 'a']]),
+      new Map([
+        [2, 'b'],
+        [1, 'a'],
+      ])
+    );
+    t.end();
+  });
+  t.on('done', () => {
+    test.strictSame(t.success, false);
+    test.end();
+  });
+});
+
+metatests.testSync('must support simple Set comparison', test => {
+  test.strictEqual(new Set([1, 2]), new Set([1, 2]));
+});
+
+metatests.test('must support simple Set comparison failure', test => {
+  const t = new metatests.ImperativeTest('mustCall test', t => {
+    t.strictEqual(new Set([1]), new Set([1, 2]));
+    t.end();
+  });
+  t.on('done', () => {
+    test.strictSame(t.success, false);
+    test.end();
+  });
+});

--- a/test/test-contains.js
+++ b/test/test-contains.js
@@ -67,6 +67,15 @@ const checkResult = (test, res, type, subObj, actual, success = true) => {
     actualRes: { 0: 'r', 1: 'm r', 2: 42, 3: 1, 4: 2 },
   },
   {
+    msg: 'sets-different-order',
+    inverse: true,
+    sort: true,
+    subObj: new Set(['r', 'm r', 42, { a: 42 }]),
+    actual: () => new Set(['m r', { a: 42 }, 'r', 42]),
+    expectedRes: { 0: 42, 1: { a: 42 }, 2: 'm r', 3: 'r' },
+    actualRes: { 0: 42, 1: { a: 42 }, 2: 'm r', 3: 'r' },
+  },
+  {
     msg: 'sets sort',
     subObj: new Set([42, 'a', 'b']),
     actual: () => new Set(['x', 'a', 'b', 42, 'z']),
@@ -92,6 +101,23 @@ const checkResult = (test, res, type, subObj, actual, success = true) => {
     actual: base => new Map([['c', 55], ...base, [1, 2], ['z', 99]]),
     expectedRes: { a: 42, b: 13, d: 66 },
     actualRes: { c: 55, a: 42, b: 13, d: 66, 1: 2, z: 99 },
+  },
+  {
+    msg: 'map-different-order',
+    inverse: true,
+    subObj: new Map([
+      ['a', 42],
+      ['b', 13],
+      ['d', 66],
+    ]),
+    actual: () =>
+      new Map([
+        ['b', 13],
+        ['d', 66],
+        ['a', 42],
+      ]),
+    expectedRes: { a: 42, b: 13, d: 66 },
+    actualRes: { a: 42, b: 13, d: 66 },
   },
   {
     msg: 'object-map',
@@ -130,7 +156,7 @@ const checkResult = (test, res, type, subObj, actual, success = true) => {
     expectedRes: { 0: 42, 1: 'a', 2: 'b' },
     actualRes: { 0: 42, 1: 'a', 2: 'b', 3: 'z' },
   },
-].forEach(({ msg, subObj, actual, sort, expectedRes, actualRes }) => {
+].forEach(({ msg, inverse, subObj, actual, sort, expectedRes, actualRes }) => {
   actual = actual(subObj);
 
   test.testSync('test.contains ' + msg, t => {
@@ -155,7 +181,7 @@ const checkResult = (test, res, type, subObj, actual, success = true) => {
       'contains',
       actualRes || actual,
       expectedRes || subObj,
-      false
+      !!inverse
     );
   });
 
@@ -169,7 +195,7 @@ const checkResult = (test, res, type, subObj, actual, success = true) => {
     sub.containsGreedy(subObj, actual);
     sub.end();
     t.log(sub.results[0]);
-    checkResult(t, sub.results[0], 'containsGreedy', actual, subObj, false);
+    checkResult(t, sub.results[0], 'containsGreedy', actual, subObj, !!inverse);
   });
 });
 

--- a/test/unit/compare.js
+++ b/test/unit/compare.js
@@ -84,6 +84,70 @@ assert(equal(null, null));
 assert(!equal({}, null));
 assert(!equal(null, {}));
 
+assert(equal(new Map(), new Map()));
+assert(equal(new Map([[1, 'a']]), new Map([[1, 'a']])));
+assert(
+  equal(
+    new Map([
+      [1, 'a'],
+      [2, 'b'],
+    ]),
+    new Map([
+      [1, 'a'],
+      [2, 'b'],
+    ])
+  )
+);
+assert(
+  !equal(
+    new Map([
+      [1, 'a'],
+      [2, 'b'],
+    ]),
+    new Map([
+      [2, 'b'],
+      [1, 'a'],
+    ])
+  )
+);
+assert(
+  !equal(
+    new Map([[1, 'a']]),
+    new Map([
+      [2, 'b'],
+      [1, 'a'],
+    ])
+  )
+);
+assert(
+  !equal(
+    new Map([
+      [1, 'a'],
+      [2, 'b'],
+    ]),
+    new Map([[1, 'a']])
+  )
+);
+assert(
+  !equal(
+    new Map([
+      [1, 'a'],
+      [3, 'c'],
+    ]),
+    new Map([
+      [1, 'a'],
+      [2, 'b'],
+    ])
+  )
+);
+
+assert(equal(new Set(), new Set()));
+assert(equal(new Set([1]), new Set([1])));
+assert(equal(new Set([1, 2]), new Set([1, 2])));
+assert(!equal(new Set([1, 2]), new Set([2, 1])));
+assert(!equal(new Set([1, 2]), new Set([1])));
+assert(!equal(new Set([1]), new Set([2])));
+
 assert(
   equal(
     () => {},
@@ -244,6 +308,70 @@ assert(strictEqual({ field: 1 }, { field: 1 }));
 assert(!strictEqual({}, { field: 'a' }));
 assert(!strictEqual({ field: 'a' }, {}));
 assert(!strictEqual({ field: 1 }, { field: '1' }));
+
+assert(strictEqual(new Map(), new Map()));
+assert(strictEqual(new Map([[1, 'a']]), new Map([[1, 'a']])));
+assert(
+  strictEqual(
+    new Map([
+      [1, 'a'],
+      [2, 'b'],
+    ]),
+    new Map([
+      [1, 'a'],
+      [2, 'b'],
+    ])
+  )
+);
+assert(
+  !strictEqual(
+    new Map([
+      [1, 'a'],
+      [2, 'b'],
+    ]),
+    new Map([
+      [2, 'b'],
+      [1, 'a'],
+    ])
+  )
+);
+assert(
+  !strictEqual(
+    new Map([[1, 'a']]),
+    new Map([
+      [2, 'b'],
+      [1, 'a'],
+    ])
+  )
+);
+assert(
+  !strictEqual(
+    new Map([
+      [1, 'a'],
+      [2, 'b'],
+    ]),
+    new Map([[1, 'a']])
+  )
+);
+assert(
+  !strictEqual(
+    new Map([
+      [1, 'a'],
+      [3, 'c'],
+    ]),
+    new Map([
+      [1, 'a'],
+      [2, 'b'],
+    ])
+  )
+);
+
+assert(strictEqual(new Set(), new Set()));
+assert(strictEqual(new Set([1]), new Set([1])));
+assert(strictEqual(new Set([1, 2]), new Set([1, 2])));
+assert(!strictEqual(new Set([1, 2]), new Set([2, 1])));
+assert(!strictEqual(new Set([1, 2]), new Set([1])));
+assert(!strictEqual(new Set([1]), new Set([2])));
 
 assert(strictEqual(null, null));
 assert(!strictEqual({}, null));


### PR DESCRIPTION
* Map are compared element by element without order using appropriate
  equal/strictEqual function.
* Set are compared without order by searching if at least one element
  in the target Set compares (via equal/strictEqual) to true.

Note that current default tap-classic reported doesn't correctly show
diffs between Map and Set objects. The objects are properly displayed
in the raw Tap output.

Fixes: https://github.com/metarhia/metatests/issues/235